### PR TITLE
[find] add `--limit` option to limit result size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    collins-cli (0.2.4)
+    collins-cli (0.2.5)
       collins_auth (~> 0.1.2)
       collins_client (~> 0.2.16)
       colorize (~> 0.7.3)
@@ -43,3 +43,6 @@ DEPENDENCIES
   collins-cli!
   rake (~> 10.4.0)
   rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.10.6

--- a/collins-cli.gemspec
+++ b/collins-cli.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'collins-cli'
-  s.version       = '0.2.4'
+  s.version       = '0.2.5'
   s.authors       = ['Gabe Conradi']
   s.email         = ['gabe@tumblr.com','gummybearx@gmail.com']
   s.homepage      = 'http://github.com/byxorna/collins-cli'
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", '~> 3.1.0'
 
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
 end

--- a/lib/collins/cli/find.rb
+++ b/lib/collins/cli/find.rb
@@ -44,6 +44,7 @@ module Collins::CLI
         opts.on('-n','--nodeclass NODECLASS[,...]',Array, "Assets in nodeclass NODECLASS") {|v| search_attrs[:nodeclass] = v}
         opts.on('-p','--pool POOL[,...]',Array, "Assets in pool POOL") {|v| search_attrs[:pool] = v}
         opts.on('-s','--size SIZE',Integer, "Number of assets to return per page (Default: #{query_opts[:size]})") {|v| query_opts[:size] = v}
+        opts.on('--limit NUM', Integer, "Limit total results to NUM of assets") { |v| options[:limit] = v}
         opts.on('-r','--role ROLE[,...]',Array,"Assets in primary role ROLE") {|v| search_attrs[:primary_role] = v}
         opts.on('-R','--secondary-role ROLE[,...]',Array,"Assets in secondary role ROLE") {|v| search_attrs[:secondary_role] = v}
         opts.on('-i','--ip-address IP[,...]',Array,"Assets with IP address[es]") {|v| search_attrs[:ip_address] = v}
@@ -149,6 +150,7 @@ _EXAMPLES_
         assets, res = [], []
         begin
           loop do
+            break if !options[:limit].nil? and assets.length >= options[:limit]
             res = collins.find(query_opts.merge({:page => page}))
             break if res.empty?
             assets = assets.concat res
@@ -157,7 +159,11 @@ _EXAMPLES_
         rescue => e
           raise "Error querying collins: #{e.message}"
         end
-        format_assets(assets, options)
+        unless options[:limit].nil?
+          format_assets(assets.first(options[:limit]), options)
+        else
+          format_assets(assets, options)
+        end
       end
       true
     end


### PR DESCRIPTION
Sometimes when querying a large amount of assets it's only necessary to have
a few (i.e. selecting a few hosts to test something on), but if querying
against a large pool that query can be slow. Adding a limit option allows for
that set to be trimmed down without having to wait for all results to be
returned
