### PR TITLE
Remove printf evaluating desc as format string

### DIFF
--- a/lib/collins/cli/mixins.rb
+++ b/lib/collins/cli/mixins.rb
@@ -25,7 +25,6 @@ module Collins ; module CLI ; module Mixins
   end
 
   def api_call desc, method, tag, *varargs, &block
-    printf "%s %s... " % [tag, desc]
     result,message = begin
       [collins.send(method,tag,*varargs),nil]
     rescue => e


### PR DESCRIPTION
This breaks setting attributes containing % because:

        > printf "%s %s..." % [ "default", "setting test=something with % in it" ]
        ArgumentError: too few arguments
                from (irb):21:in `printf'
                from (irb):21
                from /usr/bin/irb:12:in `<main>'

Removed this because it's probably cruft.

This closes #13 