### PR TITLE
Update gemfile and fix deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     collins_auth (0.1.2)
       collins_client
       highline
-    collins_client (0.2.17)
+    collins_client (0.2.18)
       httparty (~> 0.11.0)
     colorize (0.7.7)
     diff-lcs (1.2.5)
@@ -20,7 +20,7 @@ GEM
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     rake (10.4.2)
     rspec (3.1.0)
@@ -43,3 +43,6 @@ DEPENDENCIES
   collins-cli!
   rake (~> 10.4.0)
   rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.13.6

--- a/spec/collins__cli__find_spec.rb
+++ b/spec/collins__cli__find_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Collins::CLI::Find do
   before(:each) do
-    Collins::CLI::Find.stub(:format_assets).and_return(true)
-    Collins::CLI::Find.stub_chain(:collins,:find).and_return([])
+    allow(Collins::CLI::Find).to receive(:format_assets).and_return(true)
+    allow(Collins::CLI::Find).to receive_message_chain(:collins,:find).and_return([])
     subject { Collins::CLI::Find.new }
   end
   context "#parse!" do


### PR DESCRIPTION
collins_client 0.2.18 pulls in https://github.com/tumblr/collins/commit/5e388b506feefb59a3395fdb7a45e81eab589b82
multi_json 1.12.1 pulls in some performance improvements and fixes a memory leak https://github.com/intridea/multi_json/blob/master/CHANGELOG.md

This also fixes up an annoying warning when running the rspec tests.
```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from collins-cli/spec/collins__cli__find_spec.rb:5:in `block (2 levels) in <top (required)>'.
```