### PR TITLE
Use print instead of printf

### DIFF
--- a/lib/collins/cli/mixins.rb
+++ b/lib/collins/cli/mixins.rb
@@ -25,7 +25,7 @@ module Collins ; module CLI ; module Mixins
   end
 
   def api_call desc, method, tag, *varargs, &block
-    printf "%s %s... " % [tag, desc]
+    print "%s %s... " % [tag, desc]
     result,message = begin
       [collins.send(method,tag,*varargs),nil]
     rescue => e


### PR DESCRIPTION
Interpolation is done already with %. Using printf breaks setting
attributes containing % because:

        > printf "%s %s..." % [ "default", "setting test=something with % in it" ]
        ArgumentError: too few arguments
                from (irb):21:in `printf'
                from (irb):21
                from /usr/bin/irb:12:in `<main>'

This closes #13 
/cc @byxorna That should do the job