### PR TITLE
Add Ability to Query Remote Collins

### DIFF
--- a/lib/collins/cli/find.rb
+++ b/lib/collins/cli/find.rb
@@ -10,6 +10,7 @@ module Collins::CLI
 
     PROG_NAME = 'collins find'
     QUERY_DEFAULTS = {
+      :remoteLookup => false,
       :operation => 'AND',
       :size => 100,
     }
@@ -40,6 +41,7 @@ module Collins::CLI
         opts.banner = "Usage: #{PROG_NAME} [options] [hostnamepattern]"
         opts.separator "Query options:"
         opts.on('-t','--tag TAG[,...]',Array, "Assets with tag[s] TAG") {|v| search_attrs[:tag] = v}
+        opts.on('-Z','--remote-lookup',"Query remote datacenters for asset") {|v| search_attrs[:remoteLookup] = v}
         opts.on('-T','--type TYPE',String, "Only show assets with type TYPE") {|v| search_attrs[:type] = v}
         opts.on('-n','--nodeclass NODECLASS[,...]',Array, "Assets in nodeclass NODECLASS") {|v| search_attrs[:nodeclass] = v}
         opts.on('-p','--pool POOL[,...]',Array, "Assets in pool POOL") {|v| search_attrs[:pool] = v}

--- a/spec/collins__cli__find_spec.rb
+++ b/spec/collins__cli__find_spec.rb
@@ -19,7 +19,7 @@ describe Collins::CLI::Find do
       end
     end
     [
-      %w|-ZZZZZZZ|,
+      %w|-OOOOOO|,
       %w|-K -Z_ LJIFJ?=I)|,
     ].each do |args|
       it "Should fail to parse unknown flags #{args.inspect}" do


### PR DESCRIPTION
This adds in the remoteLookup flag as seen in the asset API on
https://tumblr.github.io/collins/api.html. both r and R were taken
so I was just out of luck on that and Z came to mind but open to
other ideas. Possibly this is always the default behavior as well
and a config option should be added so you don't have to remember to
query all the collins.

Integration Test:
```
mschuett-C02TC2VYGTDY:collins-cli schuettm$ bundle exec collins find -Z -t U002144
U002144	pop-cba8fa2a.totallyarealdomain.net	popnode	Provisioned	PRODUCTION	ADMIN	POPNODE	
mschuett-C02TC2VYGTDY:collins-cli schuettm$ bundle exec collins find -t U002144
No assets found
```