### PR TITLE
Update to latest collins_cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.2.4
   - 2.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,23 @@
 PATH
   remote: .
   specs:
-    collins-cli (0.2.12)
-      collins_auth (~> 0.1.2)
-      collins_client (~> 0.2.21)
+    collins-cli (0.3.0)
+      collins_auth (~> 0.2.0)
       colorize (~> 0.7.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    collins_auth (0.1.2)
-      collins_client
+    collins_auth (0.2.0)
+      collins_client (~> 0.3.0)
       highline
-    collins_client (0.2.21)
-      httparty (~> 0.11.0)
+    collins_client (0.3.0)
+      httparty (~> 0.16.0)
     colorize (0.7.7)
-    diff-lcs (1.2.5)
-    highline (1.7.10)
-    httparty (0.11.0)
-      multi_json (~> 1.0)
+    diff-lcs (1.3)
+    highline (2.0.0)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    multi_json (1.13.1)
     multi_xml (0.6.0)
     rake (10.4.2)
     rspec (3.1.0)
@@ -45,4 +42,4 @@ DEPENDENCIES
   rspec (~> 3.1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/collins-cli.gemspec
+++ b/collins-cli.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'collins-cli'
-  s.version       = '0.2.12'
+  s.version       = '0.3.0'
   s.authors       = ['Gabe Conradi']
   s.email         = ['gabe.conradi@gmail.com','gummybearx@gmail.com']
   s.homepage      = 'http://github.com/byxorna/collins-cli'
@@ -17,11 +17,10 @@ Gem::Specification.new do |s|
   s.executables   = Dir.glob('bin/*').map{|x| File.basename x}
 
   s.add_dependency "colorize", '~> 0.7.3'
-  s.add_dependency "collins_auth", '~> 0.1.2'
-  s.add_dependency "collins_client", '~> 0.2.21'
+  s.add_dependency "collins_auth", '~> 0.2.0'
   s.add_development_dependency "rake", '~> 10.4.0'
   s.add_development_dependency "rspec", '~> 3.1.0'
 
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
Like the title says :) We need the newer `collins_cli` since it has a newer `httparty` which plays nice with `HTTP_PROXY` variables in Ruby 2+. At the same time we're dropping support for ruby 1.9.

@byxorna 